### PR TITLE
BUG FIX: BiocGenerics:::testPackage() requires the 'RUnit' package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,6 +32,7 @@ Suggests:
   PCAtools,
   cowplot,
   BiocGenerics,
+  RUnit,
   knitr,
   kableExtra
 URL: https://github.com/kevinblighe/scDataviz


### PR DESCRIPTION
Hi, when running revdep checks on my 'matrixStats', your 'scDataviz' package fails running `R CMD check --as-cran`.  It fails with:

    ```
    ...
      Welcome to Bioconductor

          Vignettes contain introductory material; view with
          'browseVignettes()'. To cite Bioconductor, see
          'citation("Biobase")', and for packages 'citation("pkgname")'.


      Attaching package: 'Biobase'

      The following object is masked from 'package:MatrixGenerics':

          rowMedians

      The following objects are masked from 'package:matrixStats':

          anyMissing, rowMedians

      Error in library("RUnit", quietly = TRUE) :
        there is no package called 'RUnit'
      Calls: <Anonymous> -> library
      Execution halted
    ```

This is because you test with `BiocGenerics:::testPackage()` which needs **RUnit** but it's never declared as a dependency in your package.   You should be able to replicate this locally if you check with `--as-cran`, which checks the package in a sandbox with only the declared dependencies (recursively) while testing.